### PR TITLE
[WEEK10] 추슬기

### DIFF
--- a/doitchuu/MakeMinimumValue.js
+++ b/doitchuu/MakeMinimumValue.js
@@ -1,0 +1,6 @@
+function solution(A, B) {
+    const sortedA = A.sort((a, b) => a - b);
+    const sortedB = B.sort((a, b) => b - a);
+    
+    return sortedA.reduce((acc, cur, index) => acc + (cur * sortedB[index]), 0);
+}

--- a/doitchuu/MaximumAndMinimum.js
+++ b/doitchuu/MaximumAndMinimum.js
@@ -1,4 +1,3 @@
-// 재업로드
 function solution(s) {
     const numList = s.split(" ").sort((a, b) => a - b);
     return numList[0] + " " + numList[numList.length - 1];

--- a/doitchuu/MaximumAndMinimum.js
+++ b/doitchuu/MaximumAndMinimum.js
@@ -1,3 +1,4 @@
+// 재업로드
 function solution(s) {
     const numList = s.split(" ").sort((a, b) => a - b);
     return numList[0] + " " + numList[numList.length - 1];

--- a/doitchuu/RepeatBinaryTransformation.js
+++ b/doitchuu/RepeatBinaryTransformation.js
@@ -1,0 +1,17 @@
+function solution(s) {
+    if (s === "1") {
+        return [0, 0];
+    }
+
+    let count = 0;
+    let zeroCount = 0;
+    
+    while (s !== "1") {
+        const length = s.replaceAll("0", "").length;
+        zeroCount += s.length - length;
+        s = length.toString(2);
+        count++;
+    }
+    
+    return [count, zeroCount];
+}


### PR DESCRIPTION
# 이렇게 풀었어요

## 1. 최솟값 만들기
- [x] 문제를 풀었어요.
- 풀이 시간 : 6분

<br />

### 1) 복잡도 계산
- 시간 복잡도: **O(n log n)**
- 공간 복잡도: **O(1)** 또는 **O(n)**

<br />

### 2) 접근 아이디어

1. A 배열은 오름차순, B 배열은 내림차순으로 정렬했다.
2. 같은 인덱스끼리 곱하면 가장 큰 수와 가장 작은 수가 짝지어지도록 만들었다.
3. 각 곱을 모두 더해서 최종 최솟값을 구했다.

<br />

### 3) 회고

가장 큰 값 * 가장 작은 값으로 해서 더하면 가장 작은 값이 나올 것 같아 해당 풀이로 진행했다.

<br />
<br />

## 2. 이진 변환 반복하기
- [x] 문제를 풀었어요.
- 풀이 시간 : 21분

<br />

### 1) 복잡도 계산
- 시간 복잡도: **O(k * n)**
- 공간 복잡도: **O(n)**

<br />

### 2) 접근 아이디어

1. 문자열에서 `0`을 제거한 뒤 남은 `1`의 개수를 구했다.
2. 제거된 `0` 개수를 누적하면서, 남은 `1` 개수를 다시 이진 문자열로 변환했다.
3. 문자열이 `"1"`이 될 때까지 반복하면서 변환 횟수와 제거한 0의 총개수를 반환했다.

<br />

### 3) 회고

이진법 변환이나 이진법 방식을 이해하면 더 쉽게도 풀 수 있을 것 같다.

다른 사람 풀이:

```javascript
function solution(s) {
    if (s === "1") return [0, 0];

    let count = 0;
    let zeroCount = 0;

    while (s !== "1") {
        let oneCount = 0;

        for (let char of s) {
            if (char === "1") oneCount++;
            else zeroCount++;
        }

        s = oneCount.toString(2);
        count++;
    }

    return [count, zeroCount];
}
```

다른 사람 풀이 핵심: 문자열을 새로 만들기보다 `for`문으로 1과 0의 개수를 바로 세서 필요한 값만 남기는 방식이었다.  
내 생각: 지피티한테 더 성능 좋은 풀이를 비교했는데, 카운팅 하는 방식으로 `for`문으로 구현하는 게 문자열을 새로 만들지 않아도 되서 이 방법도 좋을 것 같다.

<br />
<br />
